### PR TITLE
bugfix: show user's current timezone

### DIFF
--- a/components/Agenda/index.js
+++ b/components/Agenda/index.js
@@ -103,7 +103,7 @@ const Talk = ({ title, startTime, endTime, speaker }) => (
             {" "}
             {`${getTimeFormat(startTime)} - ${getTimeFormat(
               endTime
-            )} GMT+1 `}{" "}
+            )} ${getCurrentTimeZone()} `}{" "}
           </p>
         </div>
       )}
@@ -143,6 +143,11 @@ const getTimeFormat = (d) => {
     date.getMinutes() < 10 ? `0` : ""
   }${date.getMinutes()}`;
 };
+
+const getCurrentTimeZone = () => {
+  const offset = new Date().getTimezoneOffset()/-60;
+  return `GMT${offset>0?'+':''}${offset}`
+}
 
 const getEvent = ({ title, startTime, endTime }) => {
   const event = {


### PR DESCRIPTION
A small bug was noticed for users with a timezone different than "GMT+1".
The bug: in the agenda, the user sees **the right time** but the **wrong timezone**.
The fix: show the user's current timezone. 